### PR TITLE
Add additional EDR providers to EDR.cna

### DIFF
--- a/EDR.cna
+++ b/EDR.cna
@@ -1,15 +1,18 @@
-#EDR.cna
-#Author: @r3dqu1nn
-#Remotely query a system for EDR products
+## EDR.cna
+## Author: @r3dqu1nn
+## Remotely query a system for EDR products
+## Additions made by @_bin_Ash
 
-@edr = @("CiscoAMPCEFWDriver.sys", "CiscoAMPHeurDriver.sys", "cbstream.sys", "cbk7.sys", "Parity.sys", "libwamf.sys", "LRAgentMF.sys", "BrCow_x_x_x_x.sys", "brfilter.sys", "BDSandBox.sys", "TRUFOS.SYS", "AVC3.SYS", "Atc.sys", "AVCKF.SYS", "bddevflt.sys", "gzflt.sys", "bdsvm.sys", "hbflt.sys", "cve.sys", "psepfilter.sys", "cposfw.sys", "dsfa.sys", "medlpflt.sys", "epregflt.sys", "TmFileEncDmk.sys", "tmevtmgr.sys", "TmEsFlt.sys", "fileflt.sys", "SakMFile.sys", "SakFile.sys", "AcDriver.sys", "TMUMH.sys", "hfileflt.sys", "TMUMS.sys", "MfeEEFF.sys", "mfprom.sys", "hdlpflt.sys", "swin.sys", "mfehidk.sys", "mfencoas.sys", "epdrv.sys", "carbonblackk.sys", "csacentr.sys", "csaenh.sys", "csareg.sys", "csascr.sys", "csaav.sys", "csaam.sys", "esensor.sys", "fsgk.sys", "fsatp.sys", "fshs.sys", "eaw.sys", "im.sys", "csagent.sys", "rvsavd.sys", "dgdmk.sys", "atrsdfw.sys", "mbamwatchdog.sys", "edevmon.sys", "SentinelMonitor.sys", "edrsensor.sys", "ehdrv.sys", "HexisFSMonitor.sys", "CyOptics.sys", "CarbonBlackK.sys", "CyProtectDrv32.sys", "CyProtectDrv64.sys", "CRExecPrev.sys", "ssfmonm.sys", "CybKernelTracker.sys", "SAVOnAccess.sys", "savonaccess.sys", "sld.sys", "aswSP.sys", "FeKern.sys", "klifks.sys", "klifaa.sys", "Klifsm.sys", "mfeaskm.sys", "mfencfilter.sys", "WFP_MRT.sys", "groundling32.sys", "SAFE-Agent.sys", "groundling64.sys", "avgtpx86.sys", "avgtpx64.sys", "pgpwdefs.sys", "GEProtection.sys", "diflt.sys", "sysMon.sys", "ssrfsf.sys", "emxdrv2.sys", "reghook.sys", "spbbcdrv.sys", "bhdrvx86.sys", "bhdrvx64.sys", "SISIPSFileFilter.sys", "symevent.sys", "VirtualAgent.sys", "vxfsrep.sys", "VirtFile.sys", "SymAFR.sys", "symefasi.sys", "symefa.sys", "symefa64.sys", "SymHsm.sys", "evmf.sys", "GEFCMP.sys", "VFSEnc.sys", "pgpfs.sys", "fencry.sys", "symrg.sys", "cfrmd.sys", "cmdccav.sys", "cmdguard.sys", "CmdMnEfs.sys", "MyDLPMF.sys", "PSINPROC.SYS", "PSINFILE.SYS", "amfsm.sys", "amm8660.sys", "amm6460.sys");
+## List of EDR drivers
+@edr = @("psepfilter.sys", "cbfsfilter2017.sys", "cve.sys", "atrsdfw.sys", "naswSP.sys", "aswSP.sys", "avgtpx86.sys", "avgtpx64.sys", "edrsensor.sys", "hbflt.sys", "bdsvm.sys", "gzflt.sys", "bddevflt.sys", "AVCKF.SYS", "Atc.sys", "AVC3.SYS", "TRUFOS.SYS", "BDSandBox.sys", "brfilter.sys", "BrCow_x_x_x_x.sys", "bemk.sys", "CarbonBlackK.sys", "parity.sys", "cbstream.sys", "cbk7.sys", "ctifile.sys", "epregflt.sys", "medlpflt.sys", "dsfa.sys", "cposfw.sys", "CiscoAMPCEFWDriver.sys", "CiscoAMPHeurDriver.sys", "cb", "csaenh.sys", "csareg.sys", "csascr.sys", "csaav.sys", "csaam.sys", "csacentr.sys", "rvsavd.sys", "cfrmd.sys", "cmdccav.sys", "cmdguard.sys", "CmdMnEfs.sys", "MyDLPMF.sys", "im.sys", "CSDeviceControl.sys", "csagent.sys", "CSBoot.sys", "cspcm2.sys", "CybKernelTracker.sys", "CRExecPrev.sys", "CyOptics.sys", "CyProtectDrv32.sys", "CyProtectDrv64.sys.sys", "CyProtectDrv64.sys", "groundling32.sys", "groundling64.sys", "ElasticEndpoint.sys", "ElasticEndpointDriver.sys", "esensor.sys", "edevmon.sys", "ehdrv.sys", "FeKern.sys", "WFP_MRT.sys", "xfsgk.sys", "fsatp.sys", "fshs.sys", "fsgk.sys", "HexisFSMonitor.sys", "klifks.sys", "klifaa.sys", "Klifsm.sys", "LRAgentMF.sys", "mbamwatchdog.sys", "mfeaskm.sys", "mfencfilter.sys", "epdrv.sys", "mfencoas.sys", "mfehidk.sys", "swin.sys", "hdlpflt.sys", "mfprom.sys", "MfeEEFF.sys", "libwamf.sys", "telam.sys", "PSINPROC.SYS", "PSINFILE.SYS", "amfsm.sys", "amm8660.sys", "amm6460.sys", "eaw.sys", "SAFE-Agent.sys", "SentinelMonitor.sys", "SAVOnAccess.sys", "sld.sys", "SophosED.sys", "sntp.sys", "swi_callout.sys", "hmpalert.sys", "sdcfilter.sys", "SophosBootDriver.sys", "pgpwdefs.sys", "GEProtection.sys", "diflt.sys", "sysMon.sys", "ssrfsf.sys", "emxdrv2.sys", "reghook.sys", "spbbcdrv.sys", "bhdrvx86.sys", "bhdrvx64.sys", "SISIPSFileFilter", "symevent.sys", "vxfsrep.sys", "VirtFile.sys", "SymAFR.sys", "symefasi.sys", "symefa.sys", "symefa64.sys", "SymHsm.sys", "evmf.sys", "GEFCMP.sys", "VFSEnc.sys", "pgpfs.sys", "fencry.sys", "symrg.sys", "SISIPSFileFilter.sys", "TMUMS.sys", "hfileflt.sys", "TMUMH.sys", "AcDriver.sys", "SakFile.sys", "SakMFile.sys", "fileflt.sys", "TmEsFlt.sys", "tmevtmgr.sys", "TmFileEncDmk.sys", "ndgdmk.sys", "dgdmk.sys", "ssfmonm.sys");
 
-#edr_query Command Register
+
+## edr_query Command Register
 beacon_command_register("edr_query", "Queries the remote or local system for all major EDR products installed",
     "Syntax: edr_query [hostname] [arch]\n" .
     "Checks the local or remote system for installed EDR products. **Note: Use localhost for [hostname] to query the local system**");
 
-#edr_query alias
+## edr_query alias
 alias edr_query {
 	$bid = $1;
     if ($2 is $null) {
@@ -72,11 +75,16 @@ sub list {
             add(@matches, $name, 0);
         }
     }
+
     $size = size(@matches);
+
+    ## Print banner
     $out .= "\c4$size EDR Products Found!\n";
     $out .= "    \c0======================\n";
     $out .= "    | Vendor Information | \n";
     $out .= "\c0    ----------------------";
+
+    ## Initial error checking
     if (size(@matches) == 0) {
         blog($bid, "\c9No EDR products found! Operate at your own risk!");
         clear(@matches);
@@ -84,111 +92,199 @@ sub list {
     if (size(@matches) > 0) {
         blog($bid, $out);
     }
-    if ('FeKern.sys' in @matches || 'WFP_MRT.sys' in @matches) {
-        blog($bid, "FireEye Found!");
+
+    ## Driver checking
+
+    ### Absolute
+    if ('psepfilter.sys' || 'cve.sys' || 'cbfsfilter2017.sys' in @matches) {
+        blog($bid, "Absolute Found!");
     }
-    if ('eaw.sys' in @matches) {
-        blog($bid, "Raytheon Cyber Solutions Found!");
-    }
-    if ('rvsavd.sys' in @matches) {
-        blog($bid, "CJSC Returnil Software Found!");
-    }
-    if ('dgdmk.sys' in @matches) {
-        blog($bid, "Verdasys Inc. Found!");
-    }
+
+    ### Altiris (Symantec)
     if ('atrsdfw.sys' in @matches) {
         blog($bid, "Altiris (Symantec) Found!");
     }
-    if ('mbamwatchdog.sys' in @matches) {
-        blog($bid, "Malwarebytes Found!");
-    }
-    if ('edevmon.sys' in @matches || 'ehdrv.sys' in @matches) {
-        blog($bid, "ESET Found!");
-    }
-    if ('SentinelMonitor.sys' in @matches) {
-        blog($bid, "SentinelOne Found!");
-    }
-    if ('edrsensor.sys' in @matches || 'hbflt.sys' in @matches || 'bdsvm.sys' in @matches || 'gzflt.sys' in @matches || 'bddevflt.sys' in @matches || 'AVCKF.SYS' in @matches || 'Atc.sys' in @matches || 'AVC3.SYS' in @matches || 'TRUFOS.SYS' in @matches || 'BDSandBox.sys' in @matches) {
-        blog($bid, "BitDefender Found!");
-    }
-    if ('HexisFSMonitor.sys' in @matches) {
-        blog($bid, "Hexis Cyber Solutions Found!");
-    }
-    if ('CyOptics.sys' in @matches || 'CyProtectDrv32.sys' in @matches || 'CyProtectDrv64.sys' in @matches) {
-        blog($bid, "Cylance Inc. Found!");
-    }
-    if ('aswSP.sys' in @matches) {
+
+    ### Avast
+    if ('aswSP.sys' || 'naswSP.sys' in @matches) {
         blog($bid, "Avast Found!");
     }
-    if ('mfeaskm.sys' in @matches || 'mfencfilter.sys' in @matches || 'epdrv.sys' in @matches || 'mfencoas.sys' in @matches || 'mfehidk.sys' in @matches || 'swin.sys' in @matches || 'hdlpflt.sys' in @matches || 'mfprom.sys' in @matches || 'MfeEEFF.sys' in @matches) {
-        blog($bid, "McAfee Found!");
-    }
-    if ('groundling32.sys' in @matches || 'groundling64.sys' in @matches) {
-        blog($bid, "Dell Secureworks Found!");
-    }
-    if ('avgtpx86.sys' in @matches || 'avgtpx64.sys' in @matches) {
+
+    ### AVG Technologies
+    if ('avgtpx86.sys' || 'avgtpx64.sys' in @matches) {
         blog($bid, "AVG Technologies Found!");
     }
-    if ('pgpwdefs.sys' in @matches || 'GEProtection.sys' in @matches || 'diflt.sys' in @matches || 'sysMon.sys' in @matches || 'ssrfsf.sys' in @matches || 'emxdrv2.sys' in @matches || 'reghook.sys' in @matches || 'spbbcdrv.sys' in @matches || 'bhdrvx86.sys' in @matches || 'bhdrvx64.sys' in @matches || 'SISIPSFileFilter.sys' in @matches || 'symevent.sys' in @matches || 'vxfsrep.sys' in @matches || 'VirtFile.sys' in @matches || 'SymAFR.sys' in @matches || 'symefasi.sys' in @matches || 'symefa.sys' in @matches || 'symefa64.sys' in @matches || 'SymHsm.sys' in @matches || 'evmf.sys' in @matches || 'GEFCMP.sys' in @matches || 'VFSEnc.sys' in @matches || 'pgpfs.sys' in @matches || 'fencry.sys' in @matches || 'symrg.sys' in @matches) {
-        blog($bid, "Symantec Found!");
-    }               
-    if ('SAFE-Agent.sys' in @matches) {
-        blog($bid, "SAFE-Cyberdefense Found!");
+
+    ## BitDefender
+        if ('edrsensor.sys' || 'hbflt.sys' || 'bdsvm.sys' || 'gzflt.sys' || 'bddevflt.sys' || 'AVCKF.SYS' || 'Atc.sys' || 'AVC3.SYS' || 'TRUFOS.SYS' || 'BDSandBox.sys' in @matches) {
+        blog($bid, "BitDefender Found!");
     }
-    if ('CybKernelTracker.sys' in @matches) {
-        blog($bid, "CyberArk Software Found!");
+
+    ## Bromium
+    if ('brfilter.sys' || 'BrCow_x_x_x_x.sys' || 'bemk.sys' in @matches) {
+        blog($bid, "Bromium Found!");
     }
-    if ('klifks.sys' in @matches || 'klifaa.sys' in @matches || 'Klifsm.sys' in @matches) {
-        blog($bid, "Kaspersky Found!");
-    }
-    if ('SAVOnAccess.sys' in @matches || 'savonaccess.sys' in @matches || 'sld.sys' in @matches) {
-        blog($bid, "Sophos Found!");
-    }
-    if ('ssfmonm.sys' in @matches) {
-        blog($bid, "Webroot Software, Inc. Found!");
-    }
-    if ('CarbonBlackK.sys' in @matches || 'carbonblackk.sys' in @matches || "Parity.sys" in @matches || "cbk7.sys" in @matches || "cbstream.sys" in @matches) {
+
+    ### Carbon Black
+    if ('CarbonBlackK.sys' || 'carbonblackk.sys' || "Parity.sys" || "cbk7.sys" || "cbstream.sys" || "ctifile.sys" in @matches) {
         blog($bid, "Carbon Black Found!");
     }
+
+    ### Check Point Software Technologies
+    if ('epregflt.sys' || 'medlpflt.sys' || 'dsfa.sys' || 'cposfw.sys' || 'epklib.sys' in @matches) {
+        blog($bid, "Check Point Software Technologies Found!");
+    }
+
+    ### Cisco AMP
+    if ('CiscoAMPCEFWDriver.sys' || 'CiscoAMPHeurDriver.sys' in @matches) {
+        blog($bid, "Cisco AMP Found!")
+    }
+
+    ### Cisco Secure Endpoint
+    if ('csacentr.sys' || 'csaenh.sys' || 'csareg.sys' || 'csascr.sys' || 'csaav.sys' || 'csaam.sys' in @matches) {
+        blog($bid, "Cisco Found!");
+    }
+
+    ### CJSC Returnil Software
+    if ('rvsavd.sys' in @matches) {
+        blog($bid, "CJSC Returnil Software Found!");
+    }
+
+    ### Comodo Security Solutions
+    if ('cfrmd.sys' || 'cmdccav.sys' || 'cmdguard.sys' || 'CmdMnEfs.sys' || 'MyDLPMF.sys' in @matches) {
+        blog($bid, "Comodo Security Solutions Found!");
+    }
+
+    ### CrowdStrike
+    if ('im.sys' || 'CSAgent.sys' || 'CSBoot.sys' || 'CSDeviceControl.sys' || 'cspcm2.sys' in @matches) {
+        blog($bid, "CrowdStrike Found!");
+    }
+
+    ### CyberArk 
+    if ('CybKernelTracker.sys' || 'vfdrv.sys' || 'vfnet.sys' || 'vfpd.sys' in @matches ) {
+        blog($bid, "CyberArk Software Found!");
+    }
+
+    ### Cybereason
     if ('CRExecPrev.sys' in @matches) {
         blog($bid, "Cybereason Found!");
     }
-    if ('im.sys' in @matches || 'CSAgent.sys' in @matches || 'CSBoot.sys' in @matches || 'CSDeviceControl.sys' in @matches || 'cspcm2.sys' in @matches) {
-        blog($bid, "CrowdStrike Found!");
+
+    ### Cylance Inc.
+    if ('CyOptics.sys' || 'CyProtectDrv32.sys' || 'CyProtectDrv64.sys' in @matches) {
+        blog($bid, "Cylance Inc. Found!");
     }
-    if ('cfrmd.sys' in @matches || 'cmdccav.sys' in @matches || 'cmdguard.sys' in @matches || 'CmdMnEfs.sys' in @matches || 'MyDLPMF.sys' in @matches) {
-        blog($bid, "Comodo Security Solutions Found!");
+
+    ### Dell Secureworks
+    if ('groundling32.sys' || 'groundling64.sys' in @matches) {
+        blog($bid, "Dell Secureworks Found!");
     }
-    if ('PSINPROC.SYS' in @matches || 'PSINFILE.SYS' in @matches || 'amfsm.sys' in @matches || 'amm8660.sys' in @matches || 'amm6460.sys' in @matches) {
-        blog($bid, "Panda Security Found!");
+
+    ### Elastic Security for Endpoint
+    if ('ElasticEndpoint.sys' || 'ElasticEndpointDriver.sys' in @matches) {
+        blog($bid, "Elastic Security for Endpoint detected!")
     }
-    if ('fsgk.sys' in @matches || 'fsatp.sys' in @matches || 'fshs.sys' in @matches) {
-        blog($bid, "F-Secure Found!");
-    }
+
+    ### Endgame
     if ('esensor.sys' in @matches) {
         blog($bid, "Endgame Found!");
     }
-    if ('csacentr.sys' in @matches || 'csaenh.sys' in @matches || 'csareg.sys' in @matches || 'csascr.sys' in @matches || 'csaav.sys' in @matches || 'csaam.sys' in @matches) {
-        blog($bid, "Cisco Found!");
+
+    ### ESET
+    if ('edevmon.sys' || 'ehdrv.sys' || 'eamonm.sys' || 'ekbdflt.sys' in @matches) {
+        blog($bid, "ESET Found!");
     }
-    if ('TMUMS.sys' in @matches || 'hfileflt.sys' in @matches || 'TMUMH.sys' in @matches || 'AcDriver.sys' in @matches || 'SakFile.sys' in @matches || 'SakMFile.sys' in @matches || 'fileflt.sys' in @matches || 'TmEsFlt.sys' in @matches || 'tmevtmgr.sys' in @matches || 'TmFileEncDmk.sys' in @matches) {
-        blog($bid, "Trend Micro Inc Found!");
+
+    ### FireEye
+    if ('FeKern.sys' || 'WFP_MRT.sys' in @matches) {
+        blog($bid, "FireEye Found!");
     }
-    if ('epregflt.sys' in @matches || 'medlpflt.sys' in @matches || 'dsfa.sys' in @matches || 'cposfw.sys' in @matches) {
-        blog($bid, "Check Point Software Technologies Found!");
+
+    ### F-Secure
+    if ('xfsgk.sys' || 'fsgk.sys' || 'fsatp.sys' || 'fshs.sys' in @matches) {
+        blog($bid, "F-Secure Found!");
     }
-    if ('psepfilter.sys' in @matches || 'cve.sys' in @matches) {
-        blog($bid, "Absolute Found!");
+
+    ### Heix Cyber Solutions 
+    if ('HexisFSMonitor.sys' in @matches) {
+        blog($bid, "Hexis Cyber Solutions Found!");
     }
-    if ('brfilter.sys' in @matches || 'BrCow_x_x_x_x.sys' in @matches) {
-        blog($bid, "Bromium Found!");
+
+    ### Kaspersky
+    if ('klifks.sys' || 'klifaa.sys' || 'Klifsm.sys' in @matches) {
+        blog($bid, "Kaspersky Found!");
     }
+
+    ### LogRhythm
     if ('LRAgentMF.sys' in @matches) {
         blog($bid, "LogRhythm Found!");
     }
+
+    ### Malwarebytes
+    if ('mbamwatchdog.sys' in @matches) {
+        blog($bid, "Malwarebytes Found!");
+    }
+
+    ### McAfee
+    if ('mfeaskm.sys' || 'mfencfilter.sys' || 'epdrv.sys' || 'mfencoas.sys' || 'mfehidk.sys' || 'swin.sys' || 'hdlpflt.sys' || 'mfprom.sys'  || 'MfeEEFF.sys' in @matches) {
+        blog($bid, "McAfee Found!");
+    }
+
+    ### OPSWAT Inc
     if ('libwamf.sys' in @matches) {
         blog($bid, "OPSWAT Inc Found!");
     }
+
+    ### Palo Alto
+    if ('telam.sys' in @matches {
+        blog($bid, "Palo Alto Cortex Found!");
+    })
+
+    ### Panda Security
+    if ('PSINPROC.SYS' || 'PSINFILE.SYS' || 'amfsm.sys' || 'amm8660.sys' || 'amm6460.sys' in @matches) {
+        blog($bid, "Panda Security Found!");
+    }     
+
+    ### Raytheon Cyber Solutions
+    if ('eaw.sys' in @matches) {
+        blog($bid, "Raytheon Cyber Solutions Found!");
+    }
+
+    ### SAFE-Cyberdefense
+    if ('SAFE-Agent.sys' in @matches) {
+        blog($bid, "SAFE-Cyberdefense Found!");
+    }
+
+    ### SentinelOne
+    if ('SentinelMonitor.sys' in @matches) {
+        blog($bid, "SentinelOne Found!");
+    }
+
+    ### Sophos
+    if ('SAVOnAccess.sys' || 'savonaccess.sys' || 'sld.sys' || 'SophosED.sys' || 'sntp.sys' || 'swi_callout.sys' || 'hmpalert.sys' || 'sdcfilter.sys' || 'SophosBootDriver.sys' in @matches) {
+        blog($bid, "Sophos Found!");
+    }
+
+    ### Symantec
+    if ('pgpwdefs.sys' || 'GEProtection.sys' || 'diflt.sys' || 'sysMon.sys' || 'ssrfsf.sys' || 'emxdrv2.sys' || 'reghook.sys' || 'spbbcdrv.sys' || 'bhdrvx86.sys' || 'bhdrvx64.sys' || 'SISIPSFileFilter.sys' || 'symevent.sys' || 'vxfsrep.sys' || 'VirtFile.sys' || 'SymAFR.sys' || 'symefasi.sys' || 'symefa.sys' || 'symefa64.sys' || 'SymHsm.sys' || 'evmf.sys' || 'GEFCMP.sys' || 'VFSEnc.sys' || 'pgpfs.sys' in || 'fencry.sys' || 'symrg.sys' in @matches) {
+        blog($bid, "Symantec Found!");
+    }   
+
+    ### Trend Micro
+    if ('TMUMS.sys' || 'hfileflt.sys' || 'TMUMH.sys' || 'AcDriver.sys' || 'SakFile.sys' || 'SakMFile.sys' || 'fileflt.sys' || 'TmEsFlt.sys' || 'tmevtmgr.sys' || 'TmFileEncDmk.sys' in @matches) {
+        blog($bid, "Trend Micro Inc Found!");
+    }
+
+    ### Verdasys
+    if ('dgdmk.sys' || 'ndgdmk.sys' in @matches) {
+        blog($bid, "Verdasys Inc. Found!");
+    }
+
+    ### Webroot
+    if ('ssfmonm.sys' in @matches) {
+        blog($bid, "Webroot Software, Inc. Found!");
+    }
+
 }
 
 popup beacon_bottom {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Collection of Aggressor scripts for Cobalt Strike 3.0+ pulled from multiple sour
     
     ![certutil2](https://user-images.githubusercontent.com/27856212/29992549-12d45854-8f6c-11e7-95c7-c2892582f56f.PNG)
     
+* EDR.cna
+    
+    * Detects EDR solutions running on local/remote hosts
+    
 * RedTeamRepo.cna
 
     * A common collection of OS commands, and Red Team Tips for when you have no Google or RTFM on hand.


### PR DESCRIPTION
- Added 18 additional drivers
- Added support for Palo Alto Cortex 
- Commented code and organized EDR providers alphabetically
- Updated README to include `edr.cna`